### PR TITLE
[FEAT] docker-compose Redis 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,13 +55,38 @@ jobs:
           username: ec2-user
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            mkdir -p /home/ec2-user/app
+            cd /home/ec2-user/app
+            
+            cat > docker-compose.yml << 'EOF'
+            version: '3.8'
+            services:
+              app:
+                image: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/spring-vote-dev:latest
+                ports:
+                  - "8080:8080"
+                environment:
+                  - DB_HOST=${{ secrets.DB_HOST }}
+                  - DB_PORT=5432
+                  - DB_NAME=${{ secrets.DB_NAME }}
+                  - DB_USERNAME=${{ secrets.DB_USERNAME }}
+                  - DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+                  - REDIS_HOST=redis
+                  - REDIS_PORT=6379
+                  - JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+                depends_on:
+                  - redis
+                restart: unless-stopped
+            
+              redis:
+                image: redis:alpine
+                ports:
+                  - "6379:6379"
+                restart: unless-stopped
+            EOF
+            
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
-            docker pull ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/spring-vote-dev:latest
-            docker stop spring-vote || true
-            docker rm spring-vote || true
-            docker run -d --name spring-vote -p 8080:8080 \
-              -e DB_HOST=${{ secrets.DB_HOST }} \
-              -e DB_NAME=${{ secrets.DB_NAME }} \
-              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com/spring-vote-dev:latest
+            
+            docker-compose down || true
+            docker-compose pull
+            docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,14 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - DB_HOST=host.docker.internal  # ← 로컬 DB
-      - DB_PORT=5432
-      - DB_NAME=vote
-      - DB_USERNAME=postgres
-      - DB_PASSWORD=password
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - DB_NAME=${DB_NAME}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
     depends_on:
       - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  app:
+    image: ${ECR_IMAGE}
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}
+      - SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_DATA_REDIS_PORT=6379
+    depends_on:
+      - redis
+    restart: unless-stopped
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
 version: '3.8'
 services:
   app:
-    image: ${ECR_IMAGE}
+    build: .
     ports:
       - "8080:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=prod
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}
-      - SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
-      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
-      - SPRING_DATA_REDIS_HOST=redis
-      - SPRING_DATA_REDIS_PORT=6379
+      - DB_HOST=host.docker.internal  # ← 로컬 DB
+      - DB_PORT=5432
+      - DB_NAME=vote
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=password
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
     depends_on:
       - redis
-    restart: unless-stopped
 
   redis:
     image: redis:alpine
     ports:
       - "6379:6379"
-    restart: unless-stopped


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #21


## 🪐 작업 내용
- Redisson 분산락을 위한 Redis 설정 추가
- docker-compose.yml 배포 방식으로 변경
- GitHub Actions 워크플로우에서 Redis + Spring Boot 동시 배포

## ⚠️ PR 특이 사항
- EC2에 docker-compose v5 설치 필요 (이미 완료했음!)
- GitHub Secrets에 `JWT_SECRET_KEY` 추가 필요 (해놧음..)
- `docker-compose up --build` 로 로컬에서 테스트 가능합니다.

### ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [x] 리뷰어 설정을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?